### PR TITLE
Add note for partial obsoletion by CSS Images 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Create right-to-left (RTL) CSS from left-to-right (LTR) CSS, and vice versa.
 
 The library is written for [Node](http://www.nodejs.org/). However, it should be easy to use it in other contexts as well. FlipCSS can be used from the command line.
 
-PLEASE NOTE: This library will be obsoleted by [CSS3 Writing Modes](http://dev.w3.org/csswg/css3-writing-modes/).
+PLEASE NOTE: This library will be obsoleted by [CSS3 Writing Modes](http://dev.w3.org/csswg/css3-writing-modes/) and [CSS Images Level 4](http://dev.w3.org/csswg/css4-images/#bidi-images).
 
 ### Installation
 


### PR DESCRIPTION
CSS Images 4 provides bidi-sensitive images that obviate the need for separate files such as "arrow-right.png" and "arrow-left.png".
